### PR TITLE
Feat: Move o link de 'Voltar' para o topo dos posts

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -7,11 +7,11 @@ layout: default
     <div class="post-meta">
       <span>{{ page.date | date: "%B %d, %Y" }}</span>
     </div>
-    <div class="post-content">
-      {{ content }}
-    </div>
     <div class="post-navigation">
       <a href="{{ '/' | relative_url }}" class="back-link">← Voltar para a página inicial</a>
+    </div>
+    <div class="post-content">
+      {{ content }}
     </div>
   </article>
 </div>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -359,9 +359,7 @@ option {
 
 /* Post Navigation */
 .post-navigation {
-    margin-top: 40px;
-    padding-top: 20px;
-    border-top: 1px solid var(--border-color);
+    margin-bottom: 40px;
 }
 
 .back-link {


### PR DESCRIPTION
Este commit move o link '← Voltar para a página inicial' do final para o topo de cada post do blog, com base no feedback do usuário para melhorar a usabilidade.

As alterações incluem:
- A `div` `post-navigation` em `_layouts/post.html` foi movida para aparecer logo após os metadados do post.
- O CSS para `.post-navigation` em `assets/css/style.css` foi atualizado para adicionar uma margem inferior em vez de uma margem superior e uma borda, adequando-se à sua nova posição.